### PR TITLE
Use pickers for treino form

### DIFF
--- a/src/screens/AdicionarTreino/index.jsx
+++ b/src/screens/AdicionarTreino/index.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { Modal } from 'react-native';
+import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import {
   Container,
   Title,
@@ -7,14 +9,46 @@ import {
   SmallInputWrapper,
   Label,
   Button,
-  ButtonText
+  ButtonText,
+  PickerButton,
+  PickerButtonText,
+  ModalContainer,
+  ModalContent,
+  Option,
+  OptionText,
+  CancelButton,
+  CancelButtonText
 } from './style';
 
 export default function AdicionarTreino() {
   const [nome, setNome] = useState('');
-  const [data, setData] = useState(''); // Agora string simples
-  const [hora, setHora] = useState('');
+  const [data, setData] = useState(null);
+  const [hora, setHora] = useState(null);
   const [objetivo, setObjetivo] = useState('');
+  const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
+  const [isTimePickerVisible, setTimePickerVisibility] = useState(false);
+  const [isObjectivePickerVisible, setObjectivePickerVisible] = useState(false);
+
+  const showDatePicker = () => setDatePickerVisibility(true);
+  const hideDatePicker = () => setDatePickerVisibility(false);
+  const handleConfirmDate = (pickedDate) => {
+    setData(pickedDate);
+    hideDatePicker();
+  };
+
+  const showTimePicker = () => setTimePickerVisibility(true);
+  const hideTimePicker = () => setTimePickerVisibility(false);
+  const handleConfirmTime = (pickedTime) => {
+    setHora(pickedTime);
+    hideTimePicker();
+  };
+
+  const openObjectivePicker = () => setObjectivePickerVisible(true);
+  const closeObjectivePicker = () => setObjectivePickerVisible(false);
+  const selectObjective = (option) => {
+    setObjetivo(option);
+    closeObjectivePicker();
+  };
 
   return (
     <Container>
@@ -29,29 +63,57 @@ export default function AdicionarTreino() {
       <Row>
         <SmallInputWrapper>
           <Label>Data:</Label>
-          <Input
-            placeholder="DD/MM/AAAA"
-            value={data}
-            onChangeText={setData}
+          <PickerButton onPress={showDatePicker}>
+            <PickerButtonText placeholder={!data}>
+              {data ? data.toLocaleDateString('pt-BR') : 'DD/MM/AAAA'}
+            </PickerButtonText>
+          </PickerButton>
+          <DateTimePickerModal
+            isVisible={isDatePickerVisible}
+            mode="date"
+            onConfirm={handleConfirmDate}
+            onCancel={hideDatePicker}
           />
         </SmallInputWrapper>
 
         <SmallInputWrapper>
           <Label>Hora:</Label>
-          <Input
-            placeholder="00:00"
-            value={hora}
-            onChangeText={setHora}
+          <PickerButton onPress={showTimePicker}>
+            <PickerButtonText placeholder={!hora}>
+              {hora
+                ? hora.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+                : '00:00'}
+            </PickerButtonText>
+          </PickerButton>
+          <DateTimePickerModal
+            isVisible={isTimePickerVisible}
+            mode="time"
+            onConfirm={handleConfirmTime}
+            onCancel={hideTimePicker}
           />
         </SmallInputWrapper>
 
         <SmallInputWrapper>
           <Label>Objetivo:</Label>
-          <Input
-            placeholder="Hipertrofia"
-            value={objetivo}
-            onChangeText={setObjetivo}
-          />
+          <PickerButton onPress={openObjectivePicker}>
+            <PickerButtonText placeholder={!objetivo}>
+              {objetivo || 'Selecione'}
+            </PickerButtonText>
+          </PickerButton>
+          <Modal visible={isObjectivePickerVisible} transparent animationType="fade">
+            <ModalContainer>
+              <ModalContent>
+                {['Hipertrofia', 'Resistência', 'Emagrecimento', 'Flexibilidade'].map((op) => (
+                  <Option key={op} onPress={() => selectObjective(op)}>
+                    <OptionText>{op}</OptionText>
+                  </Option>
+                ))}
+                <CancelButton onPress={closeObjectivePicker}>
+                  <CancelButtonText>Cancelar</CancelButtonText>
+                </CancelButton>
+              </ModalContent>
+            </ModalContainer>
+          </Modal>
         </SmallInputWrapper>
       </Row>
 

--- a/src/screens/AdicionarTreino/style.js
+++ b/src/screens/AdicionarTreino/style.js
@@ -28,6 +28,18 @@ export const Input = styled.TextInput`
   border: 1px solid #ccc;
 `;
 
+export const PickerButton = styled.TouchableOpacity`
+  background-color: #fff;
+  border-radius: 8px;
+  padding: 10px;
+  border: 1px solid #ccc;
+`;
+
+export const PickerButtonText = styled.Text`
+  font-size: 14px;
+  color: ${props => (props.placeholder ? '#999' : '#333')};
+`;
+
 export const Row = styled.View`
   flex-direction: row;
   justify-content: space-between;
@@ -55,4 +67,37 @@ export const ButtonText = styled.Text`
   color: #fff;
   font-weight: bold;
   font-size: 16px;
+`;
+
+export const ModalContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+export const ModalContent = styled.View`
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 80%;
+`;
+
+export const Option = styled.TouchableOpacity`
+  padding: 10px 0;
+`;
+
+export const OptionText = styled.Text`
+  font-size: 16px;
+  color: #333;
+`;
+
+export const CancelButton = styled.TouchableOpacity`
+  margin-top: 10px;
+  align-items: center;
+`;
+
+export const CancelButtonText = styled.Text`
+  color: #e53935;
+  font-weight: bold;
 `;


### PR DESCRIPTION
## Summary
- add button styles for date/time pickers and custom objective picker
- switch inputs to open date/time pickers
- implement simple modal combobox for selecting objective

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840416a424c832991cdf03cff12c052